### PR TITLE
Add a bunch more aspects

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Utilities for processing pre-calculated Ephemeris data (see [swiss-ephemeris](ht
 Given an interval and a set of queries, it will efficiently traverse precalculated ephemeris in daily
 increments, or do faster interpolation of regular ephemeris data for certain queries like moon events and eclipses, and return a [`Seq`](https://hackage.haskell.org/package/containers)
 of `Events`. One can then choose to inspect the extracted events to calculate when _exactly_
-they happen -- this is recommended as an extra step, only on demand, since exactitude calculation
+they happen -- this is recommended as an extra step, only on demand, since the exactitude calculation
 needs to do some numerical interpolation, vs. simple fast daily perusal.
 
 Since the main use case is to get a sequence of events and presumably examine them, `Lens`es and `Traversal`s are
@@ -12,7 +12,7 @@ provided in the `Almanac.Optics` module to help in the otherwise tiresome deep p
 Note that there's **no dependency** on any actual `lens`-like library, so you'll have to bring your own to actually do "lens stuff" with the provided optics. 
 To illustrate how the provided optics can be brought to life with a lens library, the tests use `microlens`. I have only added the most
 obvious lenses and traversals (no `Prism`s, since I don't foresee any "construction" happening and thus `Traversal`s do the job nicely
-and don't need a dependency on `profunctors`.)
+and that obviates the need for a dependency on `profunctors`.)
 
 
 To use this library, you'll have to [get ahold of ephemeris files](https://github.com/lfborjas/swiss-ephemeris#ephemerides-files); 

--- a/src/Almanac.hs
+++ b/src/Almanac.hs
@@ -1,16 +1,19 @@
 module Almanac (
   -- * Event Types
   Event(..),
+  ExactEvent(..),
   PlanetStation(..),
   LunarPhaseInfo(..),
   EclipseInfo(..),
   Transit(..),
   Crossing(..),
+  -- ** Information within events
   Station(..),
   Zodiac(..),
   House(..),
   HouseName(..),
-  ExactEvent(..),
+  Aspect(..),
+  AspectName(..),
   -- * Event queries
   module Almanac.Query,
   -- * Event handling and processing

--- a/src/Almanac/Event/Types.hs
+++ b/src/Almanac/Event/Types.hs
@@ -253,11 +253,19 @@ data TransitPhaseName
   deriving (Eq, Show)
 
 data AspectName
-  = Sextile
+  = Conjunction
+  | Sextile
   | Square
   | Trine
   | Opposition
-  | Conjunction
+  | Quincunx
+  | SemiSextile
+  | Quintile
+  | BiQuintile
+  | Septile
+  | SemiSquare
+  | Novile
+  | Sesquisquare -- Trioctile
   deriving (Eq, Enum, Show)
 
 data Aspect = Aspect {

--- a/src/Almanac/Extras.hs
+++ b/src/Almanac/Extras.hs
@@ -180,3 +180,40 @@ defaultHouses = [I, X]
 -- a list of pairs of all planets to those
 defaultCuspTransitPairs :: [(Planet, HouseName)]
 defaultCuspTransitPairs = defaultCuspTransiting defaultHouses
+
+-- major aspects
+sextile, square, trine, opposition, conjunction :: Aspect
+conjunction = Aspect Conjunction 0 5 5
+sextile = Aspect Sextile 60 5 5
+square = Aspect Square 90 5 5
+trine = Aspect Trine 120 5 5
+opposition = Aspect Opposition 180 5 5
+
+-- minor aspects
+semiSextile, semiSquare, quintile, sesquisquare, biQuintile, quincunx :: Aspect
+semiSextile = Aspect SemiSextile 30 3 3
+semiSquare = Aspect SemiSquare 45 3 3
+quintile = Aspect Quintile 72 2 2
+sesquisquare = Aspect Sesquisquare 135 3 3
+biQuintile = Aspect BiQuintile 144 2 2
+quincunx = Aspect Quincunx 150 3 3
+
+-- per: https://en.wikipedia.org/wiki/Astrological_aspect#/media/File:12_astrological_aspects.png
+majorAspects :: [Aspect]
+majorAspects = [conjunction, semiSextile, sextile, square, trine, quincunx, opposition]
+
+defaultAspects :: [Aspect]
+defaultAspects = 
+  [
+    conjunction,
+    semiSextile,
+    semiSquare,
+    sextile,
+    quintile,
+    square,
+    trine,
+    sesquisquare,
+    biQuintile,
+    quincunx,
+    opposition
+  ]


### PR DESCRIPTION
Closes #2 

* Move aspect definitions to `Extras`, export `Aspect` constructor
  to be able to "customize" aspects
* Require choosing which aspects to look for
* Expand the `majorAspects` concept to include semisextile and quincunx
* minor README updates