### PR TITLE
Ability to collect orbs as a transit progresses

### DIFF
--- a/src/Almanac/Event/Types.hs
+++ b/src/Almanac/Event/Types.hs
@@ -305,6 +305,7 @@ data Transit over = Transit {
 , transitPhases :: !(MergeSeq TransitPhase)
 , transitIsExact :: ![JulianDayTT]
 , transitCrosses :: !EclipticLongitude
+, transitProgress :: !(S.Seq (JulianDayTT, Double))
 } deriving (Eq, Show)
 
 instance Eq a => Merge (Transit a) where
@@ -318,7 +319,8 @@ instance Eq a => Merge (Transit a) where
           transitEnds = transitEnds y,
           transitAngle = transitAngle y,
           transitOrb = transitOrb y,
-          transitPhases = transitPhases x <> transitPhases y
+          transitPhases = transitPhases x <> transitPhases y,
+          transitProgress = transitProgress x <> transitProgress y
         }
 
 -------------------------------------------------------------------------------

--- a/src/Almanac/Optics.hs
+++ b/src/Almanac/Optics.hs
@@ -16,6 +16,7 @@ import Almanac.Internal.Lens
 import Almanac.Event.Types
 import Data.Time (UTCTime)
 import Almanac.EclipticLongitude
+import qualified Data.Sequence as S
 -------------------------------------------------------------------------------
 -- Lenses for 'PlanetStation'
 -------------------------------------------------------------------------------
@@ -191,6 +192,13 @@ transitPhasesL =
     get = transitPhases
     set t p' = t{transitPhases = p'}
     
+transitProgressL :: Lens' (Transit a) (S.Seq (JulianDayTT, Double))
+transitProgressL =
+  simpleLens get set
+  where
+    get = transitProgress
+    set t p' = t{transitProgress = p'}
+
 transitIsExactL :: Lens' (Transit a) [JulianDayTT]
 transitIsExactL =
   simpleLens get set


### PR DESCRIPTION
To be able to render "surf" charts, we need to see all the orbs
a transit goes through when it's active; this is obtainable when
going through the ephemeris, but quite wasteful of space -- so I
made it optional for now.